### PR TITLE
Update go.mod w/ correct module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jinzhu/gorm
+module github.com/remohammadi/gorm
 
 require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02


### PR DESCRIPTION
Hey there, I have troubles with go mod
```
go: github.com/remohammadi/gorm@v1.9.8-0.20190508111036-bbf0e20d7fd1: parsing go.mod:
	module declares its path as: github.com/jinzhu/gorm
	        but was required as: github.com/remohammadi/gorm
```
I think this could fix it.
Thank you for maintaining this version!